### PR TITLE
add cname file to permanently set custom domain

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+djinni.xlcpp.dev


### PR DESCRIPTION
To set the custom domain setting permanently, the `gh-pages` branch must contain a file called `CNAME` containing the wanted domain.

Luckily, mkdocs will take care of this: https://www.mkdocs.org/user-guide/deploying-your-docs/#custom-domains
> So that the file does not get removed the next time you deploy, you need to copy the file to your `docs_dir`. With the file properly included in your `docs_dir`, MkDocs will include the file in your built site and push it to your "pages" branch each time you run the `gh-deploy` command.