### PR TITLE
add option to manually dispatch workflow run

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,5 +1,6 @@
 name: publish
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Since I have disabled the automatic cronjob that runs the page generation, I have to manually tell the docs to do a re-deploy when any of the repositories has a new release. But I forgot to add a way to trigger the deploy workflow...

<img src="https://media.giphy.com/media/xT5LMzIK1AdZJ4cYW4/giphy.gif" width="300" />

The `workflow_dispatch` trigger adds a button on the top of the workflow history that allows triggering it manually on any branch (It should only be used on `main`, otherwise the branch-content would be published on gh-pages).

<img width="1241" alt="Bildschirmfoto 2021-03-20 um 00 18 36" src="https://user-images.githubusercontent.com/21294002/111850912-d2dbc680-8911-11eb-917f-10cd8ac31fce.png">
