### PR TITLE
Fix broken search box css

### DIFF
--- a/docs/stylesheets/theme.css
+++ b/docs/stylesheets/theme.css
@@ -10,6 +10,11 @@
   border-radius: 12rem;
 }
 
+.md-search__form {
+  border-radius: 12rem;
+  background-color: transparent;
+}
+
 .md-header-nav__button.md-logo {
   padding: 0;
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs>=1.1
-mkdocs-material>=7.1.3
-mkdocs-monorepo-plugin
-mkdocs-git-revision-date-localized-plugin
+mkdocs==1.1
+mkdocs-material==7.2.1
+mkdocs-monorepo-plugin==0.4.15
+mkdocs-git-revision-date-localized-plugin==0.9.2


### PR DESCRIPTION
After merging the latest change (#18), I realized that the searchbox looks broken due to some small change in the `mkdocs-material` theme: 

<img width="230" alt="Bildschirmfoto 2021-07-26 um 19 34 42" src="https://user-images.githubusercontent.com/21294002/127034489-55f1703a-7b91-4a65-b9af-debf7c9f3910.png">


This PR fixes the given graphics bug & pins all Python dependencies to a specific version to avoid surprises like this in the future:

<img width="230" alt="Bildschirmfoto 2021-07-26 um 19 34 48" src="https://user-images.githubusercontent.com/21294002/127034520-ff6db0fc-efdd-4487-a168-16a8137ee14f.png">
