### PR TITLE
Add plausible analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /mkdocs.yml
 /.env
+/.vscode

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -31,12 +31,15 @@
   {% if page and page.title and not page.is_homepage %}
     {% set title = config.site_name ~ " - " ~ page.title | striptags %}
   {% endif %}
+  
+  <script defer data-domain="djinni.xlcpp.dev" src="https://plausible.io/js/plausible.js"></script>
 
   <!-- Open graph meta tags -->
   <meta property="og:type" content="website" />
   <meta property="og:title" content="{{ title }}" />
   <meta property="og:description" content="{{ config.site_description }}" />
   <meta property="og:url" content="{{ page.canonical_url }}" />
+
 
 {% endblock %}
 


### PR DESCRIPTION
See if we get at least some visitors on our docu site

This is not perfect, since vivaldi, firefox and others
still might block this tracker.

But it's better and more respected than google analytics
or other solutions