### PR TITLE
add link to plausible.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@ A few non-standard CSS-customizations have been made to the theme:
 
 - a custom color theme has been created
 - the version of each submodule is injected into `mkdocs.yml` with `./configure.sh`. The version is displayed as a small tag in the sidebar navigation.
+
+## Analytics
+
+Page analytics data is public: [plausible.io/djinni.xlcpp.dev](https://plausible.io/djinni.xlcpp.dev)


### PR DESCRIPTION
I found myself looking for the plausible link in our internal chat for a few times now. I'd like to stick it here to the Readme so me and others (but mostly me 😆 ) can find it easily. 