### PR TITLE
fix doc build: pin working jinja2 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mkdocs==1.2.3
 mkdocs-material==7.3.4
 mkdocs-monorepo-plugin==0.4.16
 mkdocs-git-revision-date-localized-plugin==0.10.0
+jinja2==3.0.3


### PR DESCRIPTION
Inspired by this fix from somebody else suffering from the issue:
https://github.com/JanusGraph/janusgraph/pull/3009/files

Upgrading the mkdocs to the latest version would also be a sufficient fix, but it introduces some small layout issues that I am too lazy to resolve right now.